### PR TITLE
Replace var with let in FastBase64_Encode function

### DIFF
--- a/js/audio/riffwave.js
+++ b/js/audio/riffwave.js
@@ -34,7 +34,7 @@ function FastBase64_Encode(src) {
   var dst = '';
   var i = 0;
   while (len > 2) {
-    n = (src[i] << 16) | (src[i + 1] << 8) | src[i + 2];
+    let n = (src[i] << 16) | (src[i + 1] << 8) | src[i + 2];
     dst += FastBase64_encLookup[n >> 12] + FastBase64_encLookup[n & 0xFFF];
     len -= 3;
     i += 3;


### PR DESCRIPTION
Update variable declaration to use modern ES6 let syntax instead of var for better block scoping in the base64 encoding logic.

This is needed to run this repo in nodejs environment. Then we can make a mcp tool for generation audio.